### PR TITLE
Changed binding.gyp to enable MacOS build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -25,7 +25,7 @@
       ],
       "conditions": [
         ['OS=="win"', {
-      	  'sources': [
+          'sources': [
             'libuiohook/src/windows/input_helper.c',
             'libuiohook/src/windows/input_hook.c',
             'libuiohook/src/windows/post_event.c',
@@ -34,7 +34,7 @@
           'include_dirs': [
             'libuiohook/src/windows'
           ]
-      	}],
+        }],
         ['OS=="linux"', {
           'defines': [
             'USE_XRANDR', 'USE_EVDEV', 'USE_XT'
@@ -45,7 +45,7 @@
             ],
           },
           'cflags': ['-std=c99', '-pedantic', '-Wall', '-pthread'],
-      	  'sources': [
+          'sources': [
             'libuiohook/src/x11/input_helper.c',
             'libuiohook/src/x11/input_hook.c',
             'libuiohook/src/x11/post_event.c',
@@ -54,7 +54,28 @@
           'include_dirs': [
             'libuiohook/src/x11'
           ]
-      	}]
+        }],
+        ['OS=="mac"', {
+          "defines":[
+            "__MACOSX_CORE__","USE_IOKIT","USE_COREFOUNDATION","USE_OBJC"
+          ],
+          "link_settings": {
+            "libraries": [
+              "-framework IOKit",
+              "-framework CoreFoundation"
+            ],
+          },
+          'cflags': ['-std=c99', '-pedantic', '-Wall', '-pthread'],
+          'sources': [
+            "libuiohook/src/darwin/input_helper.c",
+            "libuiohook/src/darwin/input_hook.c",
+            "libuiohook/src/darwin/post_event.c",
+            "libuiohook/src/darwin/system_properties.c"
+          ],
+          'include_dirs': [
+            'libuiohook/src/darwin'
+          ]
+        }]
       ]
     }
   ]


### PR DESCRIPTION
## Motivation

I was trying to build awakened-poe-trade on Mac. Running the binary after `yarn electron:serve` led to this error:

![image](https://user-images.githubusercontent.com/2937410/119242323-c6dad380-bb11-11eb-927c-2680871833c3.png)

I realized this was because uiohook-napi had no Mac binaries built, leading node_gyp to not find the required files.

## Fix

Added code to build for Macs in the bindings.gyp

## Testing

1. Built latest version by running `rm -rf build dist; yarn install; yarn build-ts`
2. Installed local uiohook-napi in Awakened POE Trade using `yarn add ../uiohook-napi`
3. Rebuilt Awakened POE Trade and ran the binary
4. Verified it no longer shows this error

Awakened POE Trade still doesn't work, but because of other lack of Mac support