### PR TITLE
Avoid crashing on JS exceptions when app is exiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "install": "node-gyp-build",
     "prebuild": "prebuildify --napi",
     "build-ts": "tsc",
-    "make-libuiohook-patch": "git -C ./libuiohook diff > ./src/libuiohook.patch",
+    "make-libuiohook-patch": "git -C ./libuiohook diff --cached > ./src/libuiohook.patch",
     "apply-libuiohook-patch": "git -C ./libuiohook apply ../src/libuiohook.patch"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "install": "node-gyp-build",
     "prebuild": "prebuildify --napi",
     "build-ts": "tsc",
-    "make-libuiohook-patch": "git -C ./libuiohook diff --cached > ./src/libuiohook.patch",
+    "make-libuiohook-patch": "git -C ./libuiohook diff > ./src/libuiohook.patch",
     "apply-libuiohook-patch": "git -C ./libuiohook apply ../src/libuiohook.patch"
   },
   "files": [

--- a/src/lib/addon.c
+++ b/src/lib/addon.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <node_api.h>
 #include <uiohook.h>
@@ -20,40 +21,44 @@ void dispatch_proc(uiohook_event* const event) {
     free(copied_event);
     return;
   }
-  NAPI_FATAL_IF_FAILED(status, "dispatch_proc", "napi_call_threadsafe_function");
+  NAPI_FATAL_IF_FAILED(NULL, status, "dispatch_proc", "napi_call_threadsafe_function");
 }
 
+/**
+ * Gets the translated event that can be passed into JS code.
+ * Returns NULL only if there's a pending JS exception.
+ */
 napi_value uiohook_to_js_event(napi_env env, uiohook_event* event) {
   napi_status status;
 
   napi_value event_obj;
   status = napi_create_object(env, &event_obj);
-  NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_object");
+  NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_object");
 
   napi_value e_type;
   status = napi_create_uint32(env, event->type, &e_type);
-  NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_uint32");
+  NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_uint32");
 
   napi_value e_altKey;
   status = napi_get_boolean(env, (event->mask & (MASK_ALT)), &e_altKey);
-  NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_get_boolean");
+  NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_get_boolean");
 
   napi_value e_ctrlKey;
   status = napi_get_boolean(env, (event->mask & (MASK_CTRL)), &e_ctrlKey);
-  NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_get_boolean");
+  NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_get_boolean");
 
   napi_value e_metaKey;
   status = napi_get_boolean(env, (event->mask & (MASK_META)), &e_metaKey);
-  NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_get_boolean");
+  NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_get_boolean");
 
   napi_value e_shiftKey;
   status = napi_get_boolean(env, (event->mask & (MASK_SHIFT)), &e_shiftKey);
-  NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_get_boolean");
+  NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_get_boolean");
 
   if (event->type == EVENT_KEY_PRESSED || event->type == EVENT_KEY_RELEASED) {
     napi_value e_keycode;
     status = napi_create_uint32(env, event->data.keyboard.keycode, &e_keycode);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_uint32");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_uint32");
 
     napi_property_descriptor descriptors[] = {
       { "type",     NULL, NULL, NULL, NULL, e_type,     napi_enumerable, NULL },
@@ -64,25 +69,25 @@ napi_value uiohook_to_js_event(napi_env env, uiohook_event* event) {
       { "keycode",  NULL, NULL, NULL, NULL, e_keycode,  napi_enumerable, NULL },
     };
     status = napi_define_properties(env, event_obj, sizeof(descriptors) / sizeof(descriptors[0]), descriptors);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_define_properties");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_define_properties");
     return event_obj;
   }
   else if (event->type == EVENT_MOUSE_MOVED || event->type == EVENT_MOUSE_PRESSED || event->type == EVENT_MOUSE_RELEASED || event->type == EVENT_MOUSE_CLICKED) {
     napi_value e_x;
     status = napi_create_int32(env, event->data.mouse.x, &e_x);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_int32");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_int32");
 
     napi_value e_y;
     status = napi_create_int32(env, event->data.mouse.y, &e_y);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_int32");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_int32");
 
     napi_value e_button;
     status = napi_create_uint32(env, event->data.mouse.button, &e_button);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_uint32");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_uint32");
 
     napi_value e_clicks;
     status = napi_create_uint32(env, event->data.mouse.clicks, &e_clicks);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_uint32");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_uint32");
 
     napi_property_descriptor descriptors[] = {
       { "type",     NULL, NULL, NULL, NULL, e_type,     napi_enumerable, NULL },
@@ -96,33 +101,33 @@ napi_value uiohook_to_js_event(napi_env env, uiohook_event* event) {
       { "clicks",   NULL, NULL, NULL, NULL, e_clicks,   napi_enumerable, NULL },
     };
     status = napi_define_properties(env, event_obj, sizeof(descriptors) / sizeof(descriptors[0]), descriptors);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_define_properties");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_define_properties");
     return event_obj;
   }
   else if (event->type == EVENT_MOUSE_WHEEL) {
     napi_value e_x;
     status = napi_create_int32(env, event->data.wheel.x, &e_x);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_int32");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_int32");
 
     napi_value e_y;
     status = napi_create_int32(env, event->data.wheel.y, &e_y);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_int32");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_int32");
 
     napi_value e_clicks;
     status = napi_create_uint32(env, event->data.wheel.clicks, &e_clicks);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_uint32");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_uint32");
 
     napi_value e_amount;
     status = napi_create_uint32(env, event->data.wheel.amount, &e_amount);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_uint32");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_uint32");
 
     napi_value e_direction;
     status = napi_create_uint32(env, event->data.wheel.direction, &e_direction);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_uint32");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_uint32");
 
     napi_value e_rotation;
     status = napi_create_int32(env, event->data.wheel.rotation, &e_rotation);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_create_int32");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_create_int32");
 
     napi_property_descriptor descriptors[] = {
       { "type",      NULL, NULL, NULL, NULL, e_type,      napi_enumerable, NULL },
@@ -138,7 +143,7 @@ napi_value uiohook_to_js_event(napi_env env, uiohook_event* event) {
       { "rotation",  NULL, NULL, NULL, NULL, e_rotation,  napi_enumerable, NULL },
     };
     status = napi_define_properties(env, event_obj, sizeof(descriptors) / sizeof(descriptors[0]), descriptors);
-    NAPI_FATAL_IF_FAILED(status, "uiohook_to_js_event", "napi_define_properties");
+    NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, "uiohook_to_js_event", "napi_define_properties");
     return event_obj;
   }
 
@@ -156,13 +161,17 @@ void tsfn_to_js_proxy(napi_env env, napi_value js_callback, void* context, void*
   napi_status status;
 
   napi_value event_obj = uiohook_to_js_event(env, event);
+  if (event_obj == NULL) {
+    // A Javascript exception is pending. Just return
+    return;
+  }
 
   napi_value global;
   status = napi_get_global(env, &global);
-  NAPI_FATAL_IF_FAILED(status, "tsfn_to_js_proxy", "napi_get_global");
+  NAPI_FATAL_IF_FAILED(env, status, "tsfn_to_js_proxy", "napi_get_global");
 
   status = napi_call_function(env, global, js_callback, 1, &event_obj, NULL);
-  NAPI_FATAL_IF_FAILED(status, "tsfn_to_js_proxy", "napi_call_function");
+  NAPI_FATAL_IF_FAILED(env, status, "tsfn_to_js_proxy", "napi_call_function");
 
   free(event);
 }
@@ -265,17 +274,17 @@ NAPI_MODULE_INIT() {
   napi_value export_fn;
 
   status = napi_create_function(env, NULL, 0, AddonStart, NULL, &export_fn);
-  NAPI_FATAL_IF_FAILED(status, "NAPI_MODULE_INIT", "napi_create_function");
+  NAPI_FATAL_IF_FAILED(env, status, "NAPI_MODULE_INIT", "napi_create_function");
   status = napi_set_named_property(env, exports, "start", export_fn);
-  NAPI_FATAL_IF_FAILED(status, "NAPI_MODULE_INIT", "napi_set_named_property");
+  NAPI_FATAL_IF_FAILED(env, status, "NAPI_MODULE_INIT", "napi_set_named_property");
 
   status = napi_create_function(env, NULL, 0, AddonStop, NULL, &export_fn);
-  NAPI_FATAL_IF_FAILED(status, "NAPI_MODULE_INIT", "napi_create_function");
+  NAPI_FATAL_IF_FAILED(env, status, "NAPI_MODULE_INIT", "napi_create_function");
   status = napi_set_named_property(env, exports, "stop", export_fn);
-  NAPI_FATAL_IF_FAILED(status, "NAPI_MODULE_INIT", "napi_set_named_property");
+  NAPI_FATAL_IF_FAILED(env, status, "NAPI_MODULE_INIT", "napi_set_named_property");
 
   status = napi_add_env_cleanup_hook(env, AddonCleanUp, NULL);
-  NAPI_FATAL_IF_FAILED(status, "NAPI_MODULE_INIT", "napi_add_env_cleanup_hook");
+  NAPI_FATAL_IF_FAILED(env, status, "NAPI_MODULE_INIT", "napi_add_env_cleanup_hook");
 
   return exports;
 }

--- a/src/lib/addon.c
+++ b/src/lib/addon.c
@@ -21,7 +21,7 @@ void dispatch_proc(uiohook_event* const event) {
     free(copied_event);
     return;
   }
-  NAPI_FATAL_IF_FAILED(NULL, status, "dispatch_proc", "napi_call_threadsafe_function");
+  NAPI_RETURN_OR_FATAL_IF_FAILED(NULL, status, "dispatch_proc", "napi_call_threadsafe_function");
 }
 
 /**
@@ -168,10 +168,16 @@ void tsfn_to_js_proxy(napi_env env, napi_value js_callback, void* context, void*
 
   napi_value global;
   status = napi_get_global(env, &global);
-  NAPI_FATAL_IF_FAILED(env, status, "tsfn_to_js_proxy", "napi_get_global");
+  if (status != napi_ok) {
+    free(event);
+    NAPI_RETURN_OR_FATAL_IF_FAILED(env, status, "tsfn_to_js_proxy", "napi_get_global");
+  }
 
   status = napi_call_function(env, global, js_callback, 1, &event_obj, NULL);
-  NAPI_FATAL_IF_FAILED(env, status, "tsfn_to_js_proxy", "napi_call_function");
+  if (status != napi_ok) {
+    free(event);
+    NAPI_RETURN_OR_FATAL_IF_FAILED(env, status, "tsfn_to_js_proxy", "napi_call_function");
+  }
 
   free(event);
 }

--- a/src/lib/napi_helpers.c
+++ b/src/lib/napi_helpers.c
@@ -10,15 +10,15 @@ napi_value error_create(napi_env env) {
   // We must retrieve the last error info before doing anything else, because
   // doing anything else will replace the last error info.
   status = napi_get_last_error_info(env, &info);
-  NAPI_FATAL_IF_FAILED(status, "error_create", "napi_get_last_error_info");
+  NAPI_FATAL_IF_FAILED(env, status, "error_create", "napi_get_last_error_info");
 
   status = napi_is_exception_pending(env, &is_exception_pending);
-  NAPI_FATAL_IF_FAILED(status, "error_create", "napi_is_exception_pending");
+  NAPI_FATAL_IF_FAILED(env, status, "error_create", "napi_is_exception_pending");
 
   // A pending exception takes precedence over any internal error status.
   if (is_exception_pending) {
     status = napi_get_and_clear_last_exception(env, &error);
-    NAPI_FATAL_IF_FAILED(status, "error_create", "napi_get_and_clear_last_exception");
+    NAPI_FATAL_IF_FAILED(env, status, "error_create", "napi_get_and_clear_last_exception");
   }
   else {
     const char* error_message = info->error_message != NULL ?
@@ -30,7 +30,7 @@ napi_value error_create(napi_env env) {
       error_message,
       strlen(error_message),
       &message);
-    NAPI_FATAL_IF_FAILED(status, "error_create", "napi_create_string_utf8");
+    NAPI_FATAL_IF_FAILED(env, status, "error_create", "napi_create_string_utf8");
 
     switch (info->error_code) {
     case napi_object_expected:
@@ -38,11 +38,11 @@ napi_value error_create(napi_env env) {
     case napi_boolean_expected:
     case napi_number_expected:
       status = napi_create_type_error(env, NULL, message, &error);
-      NAPI_FATAL_IF_FAILED(status, "error_create", "napi_create_type_error");
+      NAPI_FATAL_IF_FAILED(env, status, "error_create", "napi_create_type_error");
       break;
     default:
       status = napi_create_error(env, NULL, message, &error);
-      NAPI_FATAL_IF_FAILED(status, "error_create", "napi_create_error");
+      NAPI_FATAL_IF_FAILED(env, status, "error_create", "napi_create_error");
       break;
     }
   }

--- a/src/lib/napi_helpers.h
+++ b/src/lib/napi_helpers.h
@@ -2,12 +2,38 @@
 #define ADDON_SRC_HELPERS_H_
 
 #include <node_api.h>
+#include <stdio.h>
 
-#define NAPI_FATAL_IF_FAILED(status, location, message)  \
+// Return NULL on pending exception, or fatally error on
+// all other errors.
+#define NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, \
+  location, message)                                     \
+  do {                                                   \
+    if ((status) == napi_pending_exception) {            \
+      return NULL;                                       \
+    }                                                    \
+    NAPI_FATAL_IF_FAILED(env, status, location,          \
+      message);                                          \
+  } while (0)
+
+#define NAPI_FATAL_IF_FAILED(env, status, location,      \
+  message)                                               \
   do {                                                   \
     if ((status) != napi_ok) {                           \
+      const napi_extended_error_info* info;              \
+      char full_message[100];                            \
+      snprintf(full_message, 100, "%s", (message));      \
+      if ((env) != NULL) {                               \
+        napi_status get_error_status =                   \
+          napi_get_last_error_info((env), &info);        \
+        if (get_error_status == napi_ok &&               \
+          info->error_message != NULL) {                 \
+          snprintf(full_message, 100, "%s: %s",          \
+            (message), info->error_message);             \
+        }                                                \
+      }                                                  \
       napi_fatal_error(location, NAPI_AUTO_LENGTH,       \
-                       message, NAPI_AUTO_LENGTH);       \
+                       full_message, NAPI_AUTO_LENGTH);  \
     }                                                    \
   } while (0)
 
@@ -15,6 +41,7 @@
   if ((status) != napi_ok) {                             \
     NAPI_FATAL_IF_FAILED(                                \
       napi_throw(env, error_create(env)),                \
+      env,                                               \
       "NAPI_THROW_IF_FAILED_VOID",                       \
       "napi_throw");                                     \
     return;                                              \
@@ -23,6 +50,7 @@
 #define NAPI_THROW_IF_FAILED(env, status, ...)           \
   if ((status) != napi_ok) {                             \
     NAPI_FATAL_IF_FAILED(                                \
+      env,                                               \
       napi_throw(env, error_create(env)),                \
       "NAPI_THROW_IF_FAILED_VOID",                       \
       "napi_throw");                                     \
@@ -32,6 +60,7 @@
 #define NAPI_THROW_VOID(env, code, msg)                  \
   do {                                                   \
     NAPI_FATAL_IF_FAILED(                                \
+      env,                                               \
       napi_throw_error(env, (code), (msg)),              \
       "NAPI_THROW_VOID",                                 \
       "napi_throw_error");                               \
@@ -41,6 +70,7 @@
 #define NAPI_THROW(env, code, msg, ...)                  \
   do {                                                   \
     NAPI_FATAL_IF_FAILED(                                \
+      env,                                               \
       napi_throw_error(env, (code), (msg)),              \
       "NAPI_THROW",                                      \
       "napi_throw_error");                               \

--- a/src/lib/napi_helpers.h
+++ b/src/lib/napi_helpers.h
@@ -6,6 +6,10 @@
 
 // Return NULL on pending exception, or fatally error on
 // all other errors.
+//
+// This allows us to return control to JS code ASAP, as
+// recommended by:
+// https://nodejs.org/api/n-api.html#:~:text=when%20an%20exception%20is%20pending
 #define NAPI_RETURN_NULL_OR_FATAL_IF_FAILED(env, status, \
   location, message)                                     \
   do {                                                   \

--- a/src/lib/napi_helpers.h
+++ b/src/lib/napi_helpers.h
@@ -20,6 +20,16 @@
       message);                                          \
   } while (0)
 
+#define NAPI_RETURN_OR_FATAL_IF_FAILED(env, status,      \
+  location, message)                                     \
+  do {                                                   \
+    if ((status) == napi_pending_exception) {            \
+      return;                                            \
+    }                                                    \
+    NAPI_FATAL_IF_FAILED(env, status, location,          \
+      message);                                          \
+  } while (0)
+
 #define NAPI_FATAL_IF_FAILED(env, status, location,      \
   message)                                               \
   do {                                                   \

--- a/src/libuiohook.patch
+++ b/src/libuiohook.patch
@@ -1,3 +1,25 @@
+diff --git a/src/darwin/input_hook.c b/src/darwin/input_hook.c
+index 71a83db..58649c1 100644
+--- a/src/darwin/input_hook.c
++++ b/src/darwin/input_hook.c
+@@ -1047,12 +1047,13 @@ CGEventRef hook_event_proc(CGEventTapProxy tap_proxy, CGEventType type, CGEventR
+ 			// Check for an old OS X bug where the tap seems to timeout for no reason.
+ 			// See: http://stackoverflow.com/questions/2969110/cgeventtapcreate-breaks-down-mysteriously-with-key-down-events#2971217
+ 			if (type == (CGEventType) kCGEventTapDisabledByTimeout) {
+-				logger(LOG_LEVEL_WARN, "%s [%u]: CGEventTap timeout!\n",
++				logger(LOG_LEVEL_WARN, "%s [%u]: CGEventTap timeout! Skipping\n",
+ 						__FUNCTION__, __LINE__);
+ 
+-				// We need to restart the tap!
+-				restart_tap = true;
+-				CFRunLoopStop(CFRunLoopGetCurrent());
++				// We don't restart the tap because doing so causes the program to
++				// not exit cleanly
++				// restart_tap = true;
++				// CFRunLoopStop(CFRunLoopGetCurrent());
+ 			}
+ 			else {
+ 				// In theory this *should* never execute.
 diff --git a/src/windows/input_helper.c b/src/windows/input_helper.c
 index bce0642..d203779 100644
 --- a/src/windows/input_helper.c


### PR DESCRIPTION
## Motivation

### Crashes

While testing awakened-poe-trade on Mac, I noticed that quitting Awakened POE Trade would cause a crash instead of exiting gracefully.

To reproduce:

1. Checkout the pull request for Mac at [#403](https://github.com/SnosMe/awakened-poe-trade/pull/403)
2. `yarn electron:serve` in awakened-poe-trade
3. Open PathOfExile and use it for a little
4. Use the tray to quit Awakened POE Trade

It'll give a stacktrace like this and an unexpected closing error:

```
FATAL ERROR: uiohook_to_js_event napi_define_properties
 1: 0x112458395 node::Buffer::New(v8::Isolate*, char*, unsigned long, void (*)(char*, void*), void*) [/Users/harry/code/awakened-poe-trade/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 2: 0x112458534 node::Buffer::New(v8::Isolate*, char*, unsigned long, void (*)(char*, void*), void*) [/Users/harry/code/awakened-poe-trade/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 3: 0x1124583b9 node::Buffer::New(v8::Isolate*, char*, unsigned long, void (*)(char*, void*), void*) [/Users/harry/code/awakened-poe-trade/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 4: 0x112431ac4 napi_fatal_error [/Users/harry/code/awakened-poe-trade/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 5: 0x119a0b236 uiohook_to_js_event [/Users/harry/code/awakened-poe-trade/node_modules/uiohook-napi/prebuilds/darwin-x64/node.napi.node]
 6: 0x119a0b271 tsfn_to_js_proxy [/Users/harry/code/awakened-poe-trade/node_modules/uiohook-napi/prebuilds/darwin-x64/node.napi.node]
 7: 0x1124343ae napi_ref_threadsafe_function [/Users/harry/code/awakened-poe-trade/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 8: 0x10fb1253f uv_idle_stop [/Users/harry/code/awakened-poe-trade/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
 9: 0x10fb0c5ac uv_run [/Users/harry/code/awakened-poe-trade/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework]
```

### Hang when exiting

Sometimes, when I close Awakened POE Trade via the dock, it fails to exit. It seems to do this only after the error message:

```
CGEventTap timeout!
```

## Fix

1. Added extra logging to errors where the status is not OK
   - We now also try to get the latest original error and add that to the printed message. From that, I saw that the error was actually caused by a pending exception
2. Instead of crashing on pending exceptions, just return ASAP to allow the JS to take over, per the [recommendations from Node.js docs](https://nodejs.org/api/n-api.html#:~:text=when%20an%20exception%20is%20pending)
   - Added new macro to return on pending exceptions
3. Added patch to libuiohook to avoid stopping the event thread. This prevents libuiohook from hanging and stopping the app from exiting

## Testing

1. Run `yarn prebuild` on local version
2. `yarn add ../uiohook-napi` to install local version
3. Run through same steps. No error occurs